### PR TITLE
Bugfix: Force en_US locale to support apps with a different default locale

### DIFF
--- a/lib/models/viewmodels/tweet_vm.dart
+++ b/lib/models/viewmodels/tweet_vm.dart
@@ -73,8 +73,8 @@ class TweetVM {
       );
 
   static String _createdAt(Tweet tweet) {
-    DateFormat twitterFormat = new DateFormat("EEE MMM dd HH:mm:ss '+0000' yyyy");
-    DateFormat displayFormat = new DateFormat("HH:mm • MM.dd.yyyy");
+    DateFormat twitterFormat = new DateFormat("EEE MMM dd HH:mm:ss '+0000' yyyy", 'en_US');
+    DateFormat displayFormat = new DateFormat("HH:mm • MM.dd.yyyy", 'en_US');
     final dateTime = twitterFormat.parseUTC(tweet.createdAt);
     return displayFormat.format(dateTime);
   }


### PR DESCRIPTION
* When using the tweet_ui with an app that has a default locale different to 'en_US', it will crash. Twitter always has US dates, so the days and months in other languages don't match. This fix will make sure to always format the date as an US date.