### PR TITLE
Added videoPlayerInitialVolume to TweetView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `videoPlayerInitialVolume` option to TweetView allowing to set an initial volume when the Tweet has a video. The default value is set to 0.0 schibsted/tweet_ui#33
 
 ## [2.1.0+1] - 24.04.2020
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added `videoPlayerInitialVolume` option to TweetView allowing to set an initial volume when the Tweet has a video. The default value is set to 0.0 schibsted/tweet_ui#33
+- Added `videoPlayerInitialVolume` option to TweetView, CompactTweetView and EmbeddedTweetView allowing to set an initial volume when the Tweet has a video. The default value is set to 0.0 schibsted/tweet_ui#33
 
 ## [2.1.0+1] - 24.04.2020
 ### Changed

--- a/lib/compact_tweet_view.dart
+++ b/lib/compact_tweet_view.dart
@@ -59,6 +59,9 @@ class CompactTweetView extends StatelessWidget {
   /// If set to false a image placeholder will he shown and a video will be played in a new page.
   final bool useVideoPlayer;
 
+  /// If the Tweet contains a video then an initial volume can be specified with a value between 0.0 and 1.0.
+  final double videoPlayerInitialVolume;
+
   /// Function used when you want a custom image tapped callback
   final OnTapImage onTapImage;
 
@@ -79,6 +82,7 @@ class CompactTweetView extends StatelessWidget {
       this.quoteBackgroundColor,
       this.backgroundColor,
       this.useVideoPlayer,
+      this.videoPlayerInitialVolume,
       this.onTapImage,
       this.createdDateDisplayFormat}); //  TweetView(this.tweetVM);
 
@@ -97,6 +101,7 @@ class CompactTweetView extends StatelessWidget {
       this.quoteBackgroundColor = Colors.white,
       this.backgroundColor = Colors.white,
       this.useVideoPlayer = true,
+      this.videoPlayerInitialVolume = 0.0,
       this.onTapImage,
       this.createdDateDisplayFormat})
       : _tweetVM = TweetVM.fromApiModel(tweet, createdDateDisplayFormat);
@@ -142,6 +147,7 @@ class CompactTweetView extends StatelessWidget {
                           _tweetVM,
                           ViewMode.compact,
                           useVideoPlayer: useVideoPlayer,
+                          videoPlayerInitialVolume: videoPlayerInitialVolume,
                           onTapImage: onTapImage,
                         ),
                         GestureDetector(

--- a/lib/embedded_tweet_view.dart
+++ b/lib/embedded_tweet_view.dart
@@ -28,6 +28,9 @@ class EmbeddedTweetView extends StatelessWidget {
   /// If set to false a image placeholder will he shown and a video will be played in a new page.
   final bool useVideoPlayer;
 
+  /// If the Tweet contains a video then an initial volume can be specified with a value between 0.0 and 1.0.
+  final double videoPlayerInitialVolume;
+
   /// Function used when you want a custom image tapped callback
   final OnTapImage onTapImage;
 
@@ -39,6 +42,7 @@ class EmbeddedTweetView extends StatelessWidget {
     this.backgroundColor,
     this.darkMode,
     this.useVideoPlayer,
+    this.videoPlayerInitialVolume,
     this.onTapImage,
     this.createdDateDisplayFormat,
   }); //  TweetView(this.tweetVM);
@@ -47,6 +51,7 @@ class EmbeddedTweetView extends StatelessWidget {
       {this.backgroundColor = Colors.white,
       this.darkMode = false,
       this.useVideoPlayer = true,
+      this.videoPlayerInitialVolume = 0.0,
       this.onTapImage,
       this.createdDateDisplayFormat})
       : _tweetVM = TweetVM.fromApiModel(tweet, createdDateDisplayFormat);
@@ -169,6 +174,7 @@ class EmbeddedTweetView extends StatelessWidget {
               _tweetVM,
               ViewMode.standard,
               useVideoPlayer: useVideoPlayer,
+              videoPlayerInitialVolume: videoPlayerInitialVolume,
               onTapImage: onTapImage,
             ),
           ),

--- a/lib/src/media_container.dart
+++ b/lib/src/media_container.dart
@@ -19,12 +19,14 @@ class MediaContainer extends StatefulWidget {
     this.viewMode, {
     Key key,
     this.useVideoPlayer = true,
+    this.videoPlayerInitialVolume = 0.0,
     this.onTapImage,
   }) : super(key: key);
 
   final TweetVM tweetVM;
   final ViewMode viewMode;
   final bool useVideoPlayer;
+  final double videoPlayerInitialVolume;
 
   @override
   _MediaContainerState createState() => _MediaContainerState();
@@ -47,7 +49,10 @@ class _MediaContainerState extends State<MediaContainer>
     Widget child;
     if (widget.tweetVM.getDisplayTweet().hasSupportedVideo) {
       if (widget.useVideoPlayer) {
-        child = TweetVideo(widget.tweetVM.getDisplayTweet());
+        child = TweetVideo(
+          widget.tweetVM.getDisplayTweet(),
+          initialVolume: widget.videoPlayerInitialVolume
+        );
       } else {
         child = Stack(
           children: <Widget>[

--- a/lib/src/tweet_video.dart
+++ b/lib/src/tweet_video.dart
@@ -9,9 +9,11 @@ class TweetVideo extends StatefulWidget {
   TweetVideo(
     this.tweetVM, {
     Key key,
+    this.initialVolume = 0.0
   }) : super(key: key);
 
   final TweetVM tweetVM;
+  final double initialVolume;
 
   @override
   _TweetVideoState createState() => _TweetVideoState();
@@ -27,7 +29,7 @@ class _TweetVideoState extends State<TweetVideo>
     super.initState();
     _controller = VideoPlayerController.network(
         widget.tweetVM.getDisplayTweet().videoUrl);
-    _controller.setVolume(0.0);
+    _controller.setVolume(widget.initialVolume);
 
     _chewieController = ChewieController(
       videoPlayerController: _controller,

--- a/lib/tweet_view.dart
+++ b/lib/tweet_view.dart
@@ -58,6 +58,9 @@ class TweetView extends StatelessWidget {
   /// If set to false a image placeholder will he shown and a video will be played in a new page.
   final bool useVideoPlayer;
 
+  /// If the Tweet contains a video then an initial volume can be specified with a value between 0.0 and 1.0.
+  final double videoPlayerInitialVolume;
+
   /// Function used when you want a custom image tapped callback
   final OnTapImage onTapImage;
 
@@ -79,6 +82,7 @@ class TweetView extends StatelessWidget {
     this.quoteBackgroundColor,
     this.backgroundColor,
     this.useVideoPlayer,
+    this.videoPlayerInitialVolume,
     this.onTapImage,
     this.createdDateDisplayFormat,
   }); //  TweetView(this.tweetVM);
@@ -97,6 +101,7 @@ class TweetView extends StatelessWidget {
       this.quoteBackgroundColor = Colors.white,
       this.backgroundColor = Colors.white,
       this.useVideoPlayer = true,
+      this.videoPlayerInitialVolume = 0.0,
       this.onTapImage,
       this.createdDateDisplayFormat})
       : _tweetVM = TweetVM.fromApiModel(tweet, createdDateDisplayFormat);
@@ -111,6 +116,7 @@ class TweetView extends StatelessWidget {
             _tweetVM,
             ViewMode.standard,
             useVideoPlayer: useVideoPlayer,
+            videoPlayerInitialVolume: videoPlayerInitialVolume,
             onTapImage: onTapImage,
           ),
           GestureDetector(


### PR DESCRIPTION
An option to set an initial volume into Tweet view has been added.

The value must be between 0.0 and 1.0. I was thinking about add an assert but video_player library used by Chewie clamps the value of the volume into that range. 

This is aim to add the feature request: schibsted/tweet_ui#33