### PR TITLE
Adding support for single tweet in data response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Adding android:exported="true" to example app to be able to run it on Android 12
+- Added support for single tweet in data response (e.g. from GET /2/tweets/:id endpoint)
 
 ## [4.0.0-dev.0] - 18.02.2022
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ TweetView.fromTweetV2(
     TweetV2Response.fromRawJson(
         jsonFromTwitterAPI
         // {"data": ["created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+        // or
+        // {"data": {"created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
     )
 );
 ```
@@ -55,6 +57,8 @@ CompactTweetView.fromTweetV2(
     TweetV2Response.fromRawJson(
         jsonFromTwitterAPI
         // {"data": ["created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+        // or
+        // {"data": {"created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
     )
 );
 ```
@@ -78,6 +82,8 @@ EmbeddedTweetView.fromTweetV2(
     TweetV2Response.fromRawJson(
       jsonFromTwitterAPI
       // {"data": ["created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+      // or
+      // {"data": {"created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
     )
     darkMode: true,
 )

--- a/example/assets/tweet_v2_examples/single_tweet.json
+++ b/example/assets/tweet_v2_examples/single_tweet.json
@@ -1,0 +1,53 @@
+{
+  "data": {
+    "public_metrics": {
+      "retweet_count": 60,
+      "reply_count": 1,
+      "like_count": 1127,
+      "quote_count": 2
+    },
+    "text": "💚 https://t.co/aQzfPXXblD",
+    "attachments": {
+      "media_keys": [
+        "3_1502580661231792138",
+        "3_1502580676830404615",
+        "3_1502580690411479041"
+      ]
+    },
+    "created_at": "2022-03-12T09:42:08.000Z",
+    "author_id": "1016076290",
+    "id": "1502580693011996674"
+  },
+  "includes": {
+    "media": [
+      {
+        "url": "https://pbs.twimg.com/media/FNo9Jn8XsAoIwFn.jpg",
+        "width": 2048,
+        "media_key": "3_1502580661231792138",
+        "height": 2048,
+        "type": "photo"
+      },
+      {
+        "url": "https://pbs.twimg.com/media/FNo9KiDXoAc1lRx.jpg",
+        "width": 2048,
+        "media_key": "3_1502580676830404615",
+        "height": 1363,
+        "type": "photo"
+      },
+      {
+        "url": "https://pbs.twimg.com/media/FNo9LUpWYAELulQ.jpg",
+        "width": 2048,
+        "media_key": "3_1502580690411479041",
+        "height": 1366,
+        "type": "photo"
+      }
+    ],
+    "users": [
+      {
+        "id": "1016076290",
+        "name": "Sebastian Vettel #5",
+        "username": "sebvettelnews"
+      }
+    ]
+  }
+}

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -1,0 +1,20 @@
+//
+// Generated file. Do not edit.
+//
+
+// ignore_for_file: directives_ordering
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:url_launcher_web/url_launcher_web.dart';
+import 'package:video_player_web/video_player_web.dart';
+import 'package:wakelock_web/wakelock_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// ignore: public_member_api_docs
+void registerPlugins(Registrar registrar) {
+  UrlLauncherPlugin.registerWith(registrar);
+  VideoPlayerPlugin.registerWith(registrar);
+  WakelockWeb.registerWith(registrar);
+  registrar.registerMessageHandler();
+}

--- a/example/lib/tweet_v2_page.dart
+++ b/example/lib/tweet_v2_page.dart
@@ -56,6 +56,11 @@ class TweetV2Page extends StatelessWidget {
             tweetPath: 'assets/tweet_v2_examples/tiny_tweet.json',
             tweetType: TweetType.v2,
           ),
+          OpenTweetPageButton(
+            title: "Single tweet",
+            tweetPath: 'assets/tweet_v2_examples/single_tweet.json',
+            tweetType: TweetType.v2,
+          ),
         ],
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -405,7 +405,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "4.0.0-dev.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/models/api/v2/tweet_v2.dart
+++ b/lib/models/api/v2/tweet_v2.dart
@@ -35,6 +35,11 @@ class TweetV2Response {
 
   /// For the sake of this library we always assume there is exactly one tweet to be displayed
   static TweetV2 _getTweet(Object data) {
+    /// Case for referenced tweets
+    if (data is List<TweetV2>) {
+      return data.first;
+    }
+
     if (data is List) {
       return TweetV2.fromJson(data.first as Map<String, dynamic>);
     }

--- a/lib/models/api/v2/tweet_v2.dart
+++ b/lib/models/api/v2/tweet_v2.dart
@@ -29,9 +29,19 @@ class TweetV2Response {
     this.includes = const TweetV2Includes(),
   }) : tweet = _getTweet(data);
 
+  /// This function can accept both JSON that has a list and a single object in [data] field
+  /// So both
+  /// - {"data": ["created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+  /// - {"data": {"created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+  /// are valid
   factory TweetV2Response.fromRawJson(String str) =>
       TweetV2Response.fromJson(json.decode(str));
 
+  /// This function can accept both JSON that has a list and a single object in [data] field
+  /// So both
+  /// - {"data": ["created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+  /// - {"data": {"created_at": "2020-09-18T18:36:15.000Z", "id": "1061967001177018368", ...
+  /// are valid
   factory TweetV2Response.fromJson(Map<String, dynamic> json) =>
       _$TweetV2ResponseFromJson(json);
 

--- a/lib/models/api/v2/tweet_v2.dart
+++ b/lib/models/api/v2/tweet_v2.dart
@@ -12,25 +12,34 @@ part 'tweet_v2.g.dart';
 /// Those need to be included in expansion parameters.
 @JsonSerializable()
 class TweetV2Response {
-  /// This field will contain the actual tweet, in this library we assume it will have exactly one element
-  final List<TweetV2> data;
+  /// This field will contain the actual tweet.
+  /// One endpoints of twitter API returns here a list an another returns a single object, hence Object
+  /// but in reality it should always be either TweetV2 or List<TweetV2>
+  /// If response is a list we always take the first element
+  final Object data;
 
   /// This field will contain any objects referenced from tweet inside data field, like media, users or tweets
   final TweetV2Includes includes;
 
-  const TweetV2Response({
+  /// This is the tweet extracted from [data] field
+  final TweetV2 tweet;
+
+  TweetV2Response({
     required this.data,
     this.includes = const TweetV2Includes(),
-  });
+  }) : tweet = _getTweet(data);
 
-  factory TweetV2Response.fromRawJson(String str) =>
-      TweetV2Response.fromJson(json.decode(str));
+  factory TweetV2Response.fromRawJson(String str) => TweetV2Response.fromJson(json.decode(str));
 
-  factory TweetV2Response.fromJson(Map<String, dynamic> json) =>
-      _$TweetV2ResponseFromJson(json);
+  factory TweetV2Response.fromJson(Map<String, dynamic> json) => _$TweetV2ResponseFromJson(json);
 
   /// For the sake of this library we always assume there is exactly one tweet to be displayed
-  TweetV2 get tweet => data.first;
+  static TweetV2 _getTweet(Object data) {
+    if (data is List) {
+      return TweetV2.fromJson(data.first as Map<String, dynamic>);
+    }
+    return TweetV2.fromJson(data as Map<String, dynamic>);
+  }
 }
 
 @JsonSerializable()
@@ -80,8 +89,7 @@ class TweetV2 {
     this.publicMetrics = const TweetV2PublicMetrics.empty(),
   });
 
-  factory TweetV2.fromJson(Map<String, dynamic> json) =>
-      _$TweetV2FromJson(json);
+  factory TweetV2.fromJson(Map<String, dynamic> json) => _$TweetV2FromJson(json);
 }
 
 enum ReferencedTweetType {
@@ -101,8 +109,7 @@ class ReferencedTweet {
 
   const ReferencedTweet(this.type, this.id);
 
-  factory ReferencedTweet.fromJson(Map<String, dynamic> json) =>
-      _$ReferencedTweetFromJson(json);
+  factory ReferencedTweet.fromJson(Map<String, dynamic> json) => _$ReferencedTweetFromJson(json);
 }
 
 @JsonSerializable()
@@ -114,8 +121,7 @@ class TweetV2Attachment {
 
   const TweetV2Attachment.empty() : this.mediaKeys = const [];
 
-  factory TweetV2Attachment.fromJson(Map<String, dynamic> json) =>
-      _$TweetV2AttachmentFromJson(json);
+  factory TweetV2Attachment.fromJson(Map<String, dynamic> json) => _$TweetV2AttachmentFromJson(json);
 }
 
 @JsonSerializable()
@@ -128,8 +134,7 @@ class TweetV2PublicMetrics {
 
   const TweetV2PublicMetrics.empty() : this.likeCount = 0;
 
-  factory TweetV2PublicMetrics.fromJson(Map<String, dynamic> json) =>
-      _$TweetV2PublicMetricsFromJson(json);
+  factory TweetV2PublicMetrics.fromJson(Map<String, dynamic> json) => _$TweetV2PublicMetricsFromJson(json);
 }
 
 @JsonSerializable()
@@ -149,6 +154,5 @@ class TweetV2Includes {
     this.media = const [],
   });
 
-  factory TweetV2Includes.fromJson(Map<String, dynamic> json) =>
-      _$TweetV2IncludesFromJson(json);
+  factory TweetV2Includes.fromJson(Map<String, dynamic> json) => _$TweetV2IncludesFromJson(json);
 }

--- a/lib/models/api/v2/tweet_v2.dart
+++ b/lib/models/api/v2/tweet_v2.dart
@@ -29,9 +29,11 @@ class TweetV2Response {
     this.includes = const TweetV2Includes(),
   }) : tweet = _getTweet(data);
 
-  factory TweetV2Response.fromRawJson(String str) => TweetV2Response.fromJson(json.decode(str));
+  factory TweetV2Response.fromRawJson(String str) =>
+      TweetV2Response.fromJson(json.decode(str));
 
-  factory TweetV2Response.fromJson(Map<String, dynamic> json) => _$TweetV2ResponseFromJson(json);
+  factory TweetV2Response.fromJson(Map<String, dynamic> json) =>
+      _$TweetV2ResponseFromJson(json);
 
   /// For the sake of this library we always assume there is exactly one tweet to be displayed
   static TweetV2 _getTweet(Object data) {
@@ -99,7 +101,8 @@ class TweetV2 {
     this.publicMetrics = const TweetV2PublicMetrics.empty(),
   });
 
-  factory TweetV2.fromJson(Map<String, dynamic> json) => _$TweetV2FromJson(json);
+  factory TweetV2.fromJson(Map<String, dynamic> json) =>
+      _$TweetV2FromJson(json);
 }
 
 enum ReferencedTweetType {
@@ -119,7 +122,8 @@ class ReferencedTweet {
 
   const ReferencedTweet(this.type, this.id);
 
-  factory ReferencedTweet.fromJson(Map<String, dynamic> json) => _$ReferencedTweetFromJson(json);
+  factory ReferencedTweet.fromJson(Map<String, dynamic> json) =>
+      _$ReferencedTweetFromJson(json);
 }
 
 @JsonSerializable()
@@ -131,7 +135,8 @@ class TweetV2Attachment {
 
   const TweetV2Attachment.empty() : this.mediaKeys = const [];
 
-  factory TweetV2Attachment.fromJson(Map<String, dynamic> json) => _$TweetV2AttachmentFromJson(json);
+  factory TweetV2Attachment.fromJson(Map<String, dynamic> json) =>
+      _$TweetV2AttachmentFromJson(json);
 }
 
 @JsonSerializable()
@@ -144,7 +149,8 @@ class TweetV2PublicMetrics {
 
   const TweetV2PublicMetrics.empty() : this.likeCount = 0;
 
-  factory TweetV2PublicMetrics.fromJson(Map<String, dynamic> json) => _$TweetV2PublicMetricsFromJson(json);
+  factory TweetV2PublicMetrics.fromJson(Map<String, dynamic> json) =>
+      _$TweetV2PublicMetricsFromJson(json);
 }
 
 @JsonSerializable()
@@ -164,5 +170,6 @@ class TweetV2Includes {
     this.media = const [],
   });
 
-  factory TweetV2Includes.fromJson(Map<String, dynamic> json) => _$TweetV2IncludesFromJson(json);
+  factory TweetV2Includes.fromJson(Map<String, dynamic> json) =>
+      _$TweetV2IncludesFromJson(json);
 }

--- a/lib/models/api/v2/tweet_v2.dart
+++ b/lib/models/api/v2/tweet_v2.dart
@@ -35,6 +35,11 @@ class TweetV2Response {
 
   /// For the sake of this library we always assume there is exactly one tweet to be displayed
   static TweetV2 _getTweet(Object data) {
+    /// If already proper object simply return it
+    if (data is TweetV2) {
+      return data;
+    }
+
     /// Case for referenced tweets
     if (data is List<TweetV2>) {
       return data.first;

--- a/lib/models/api/v2/tweet_v2.g.dart
+++ b/lib/models/api/v2/tweet_v2.g.dart
@@ -8,9 +8,7 @@ part of 'tweet_v2.dart';
 
 TweetV2Response _$TweetV2ResponseFromJson(Map<String, dynamic> json) =>
     TweetV2Response(
-      data: (json['data'] as List<dynamic>)
-          .map((e) => TweetV2.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      data: json['data'] as Object,
       includes: json['includes'] == null
           ? const TweetV2Includes()
           : TweetV2Includes.fromJson(json['includes'] as Map<String, dynamic>),


### PR DESCRIPTION
The problem is that some Twitter endpoint return a list and some a single object inside of data field.

E.g. this endpoint returns a single object - https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets-id