### PR TITLE
fix: fixed deprecated method

### DIFF
--- a/lib/compact_tweet_view.dart
+++ b/lib/compact_tweet_view.dart
@@ -191,7 +191,7 @@ class CompactTweetView extends StatelessWidget {
                         ),
                         GestureDetector(
                           onTap: () {
-                            openUrl(_tweetVM.tweetLink);
+                            openUrl(Uri.parse(_tweetVM.tweetLink));
                           },
                           child: TweetText(
                             _tweetVM,

--- a/lib/embedded_tweet_view.dart
+++ b/lib/embedded_tweet_view.dart
@@ -103,7 +103,7 @@ class EmbeddedTweetView extends StatelessWidget {
         children: <Widget>[
           GestureDetector(
             onTap: () {
-              openUrl(_tweetVM.tweetLink);
+              openUrl(Uri.parse(_tweetVM.tweetLink));
             },
             child: Padding(
               padding: const EdgeInsets.only(left: 15, right: 15, top: 15),
@@ -114,7 +114,7 @@ class EmbeddedTweetView extends StatelessWidget {
                     child: GestureDetector(
                       behavior: HitTestBehavior.translucent,
                       onTap: () {
-                        openUrl(_tweetVM.getDisplayTweet().userLink);
+                        openUrl(Uri.parse(_tweetVM.getDisplayTweet().userLink));
                       },
                       child: Stack(
                         children: <Widget>[
@@ -168,7 +168,7 @@ class EmbeddedTweetView extends StatelessWidget {
                   ),
                   GestureDetector(
                     onTap: () {
-                      openUrl(_tweetVM.tweetLink);
+                      openUrl(Uri.parse(_tweetVM.tweetLink));
                     },
                     child: TweetText(
                       _tweetVM,
@@ -276,7 +276,7 @@ class EmbeddedTweetView extends StatelessWidget {
               child: GestureDetector(
                 behavior: HitTestBehavior.translucent,
                 onTap: () {
-                  openUrl(_tweetVM.userLink);
+                  openUrl(Uri.parse(_tweetVM.userLink));
                 },
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/src/byline.dart
+++ b/lib/src/byline.dart
@@ -84,7 +84,7 @@ class Byline extends StatelessWidget {
               child: GestureDetector(
                 behavior: HitTestBehavior.translucent,
                 onTap: () {
-                  openUrl(tweetVM.getDisplayTweet().userLink);
+                  openUrl(Uri.parse(tweetVM.getDisplayTweet().userLink));
                 },
                 child: Row(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/src/quote_tweet_view.dart
+++ b/lib/src/quote_tweet_view.dart
@@ -36,7 +36,7 @@ class QuoteTweetView extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        openUrl(tweetVM.tweetLink);
+        openUrl(Uri.parse(tweetVM.tweetLink));
       },
       child: ClipRRect(
         borderRadius: BorderRadius.all(Radius.circular(8.0)),

--- a/lib/src/quote_tweet_view_embedded.dart
+++ b/lib/src/quote_tweet_view_embedded.dart
@@ -36,7 +36,7 @@ class QuoteTweetViewEmbedded extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        openUrl(tweetVM.tweetLink);
+        openUrl(Uri.parse(tweetVM.tweetLink));
       },
       child: ClipRRect(
         borderRadius: BorderRadius.all(Radius.circular(8.0)),

--- a/lib/src/retweet.dart
+++ b/lib/src/retweet.dart
@@ -19,7 +19,7 @@ class RetweetInformation extends StatelessWidget {
       return GestureDetector(
         behavior: HitTestBehavior.translucent,
         onTap: () {
-          openUrl(tweetVM.userLink);
+          openUrl(Uri.parse(tweetVM.userLink));
         },
         child: Padding(
           child: Row(

--- a/lib/src/tweet_text.dart
+++ b/lib/src/tweet_text.dart
@@ -80,7 +80,7 @@ class TweetText extends StatelessWidget {
             style: clickableTextStyle,
             recognizer: TapGestureRecognizer()
               ..onTap = () async {
-                openUrl(urlEntity.url);
+                openUrl(Uri.parse(urlEntity.url));
               },
           ));
         } else {
@@ -95,13 +95,16 @@ class TweetText extends StatelessWidget {
               ..onTap = () async {
                 if (entity.runtimeType == MentionEntity) {
                   MentionEntity mentionEntity = (entity as MentionEntity);
-                  openUrl("https://twitter.com/${mentionEntity.screenName}");
+                  openUrl(Uri.parse(
+                      "https://twitter.com/${mentionEntity.screenName}"));
                 } else if (entity.runtimeType == SymbolEntity) {
                   SymbolEntity symbolEntity = (entity as SymbolEntity);
-                  openUrl("https://twitter.com/search?q=${symbolEntity.text}");
+                  openUrl(Uri.parse(
+                      "https://twitter.com/search?q=${symbolEntity.text}"));
                 } else if (entity.runtimeType == HashtagEntity) {
                   HashtagEntity hashtagEntity = (entity as HashtagEntity);
-                  openUrl("https://twitter.com/hashtag/${hashtagEntity.text}");
+                  openUrl(Uri.parse(
+                      "https://twitter.com/hashtag/${hashtagEntity.text}"));
                 }
               },
           ));

--- a/lib/src/url_launcher.dart
+++ b/lib/src/url_launcher.dart
@@ -1,7 +1,7 @@
 import 'package:url_launcher/url_launcher.dart';
 
-void openUrl(String url) async {
-  if (await canLaunch(url)) {
-    await launch(url);
+void openUrl(Uri uri) async {
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri);
   }
 }

--- a/lib/tweet_view.dart
+++ b/lib/tweet_view.dart
@@ -159,7 +159,7 @@ class TweetView extends StatelessWidget {
           ),
           GestureDetector(
             onTap: () {
-              openUrl(_tweetVM.tweetLink);
+              openUrl(Uri.parse(_tweetVM.tweetLink));
             },
             child: Column(
               children: <Widget>[
@@ -168,7 +168,7 @@ class TweetView extends StatelessWidget {
                   child: GestureDetector(
                     behavior: HitTestBehavior.translucent,
                     onTap: () {
-                      openUrl(_tweetVM.getDisplayTweet().userLink);
+                      openUrl(Uri.parse(_tweetVM.getDisplayTweet().userLink));
                     },
                     child: Stack(
                       children: <Widget>[
@@ -210,7 +210,7 @@ class TweetView extends StatelessWidget {
                 ),
                 GestureDetector(
                   onTap: () {
-                    openUrl(_tweetVM.tweetLink);
+                    openUrl(Uri.parse(_tweetVM.tweetLink));
                   },
                   child: TweetText(
                     _tweetVM,


### PR DESCRIPTION
Fixed deprecation warnings below:

- 'canLaunch' is deprecated and shouldn't be used. Use canLaunchUrl instead.
- 'launch' is deprecated and shouldn't be used. Use launchUrl instead.